### PR TITLE
Use skipInvalid in YAML.safeDump

### DIFF
--- a/lib/hipchat.coffee
+++ b/lib/hipchat.coffee
@@ -67,7 +67,7 @@ class Hipchat extends Browser
         src: url
 
     # convert object to yaml file
-    yamlString = YAML.safeDump emoticons
+    yamlString = YAML.safeDump(emoticons, {skipInvalid: true})
 
     # write to disk
     ws = fs.createOutputStream(@path + '/' + @hipchatUsername + '.yaml')


### PR DESCRIPTION
This will allow any broken entries to be ignored.
NOTE: 
This simply allows the yaml file to be created, but there are some entries at the top that do not have names as they are Gravatar images. Might be good to modify the scraper to only find actual emoticons.